### PR TITLE
既存ページのfooterを適用するための設定を追加する

### DIFF
--- a/src/main/resources/templates/User/create.html
+++ b/src/main/resources/templates/User/create.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="ja">
 <th:block th:replace="fragment/head :: head(新規登録)"></th:block>
-<body>
+<body class="flex flex-col min-h-screen">
 <th:block th:replace="fragment/header :: header"></th:block>
-<main class="flex flex-col items-center mt-10">
+<main class="flex flex-col items-center mt-10 flex-grow">
     <h2 class="text-center sm:text-3xl text-2xl font-medium text-default">新規登録</h2>
     <!--TODO: Figmaではエラーメッセージの表示がなかったけどあってもいいかも？-->
     <!--エラーメッセージの表示-->

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="ja">
 <th:block th:replace="fragment/head :: head(ログイン)"></th:block>
-<body class="font-sans">
+<body class="flex flex-col min-h-screen">
 <th:block th:replace="fragment/header :: header"></th:block>
-<main class="flex flex-col items-center mt-10">
+<main class="flex flex-col items-center mt-10 flex-grow">
     <h2 class="text-center sm:text-3xl text-2xl font-medium text-default">ログイン</h2>
 <!--    TODO: Figmaではエラーメッセージの表示がなかったけどあってもいいかも？-->
     <!--    エラーメッセージの表示-->


### PR DESCRIPTION
## 概要
<!-- 以下にissueを記載 (close #xxx)-->
close #64 

<!-- 以下にプルリクの内容を記載 -->
- footerを適用させるためのコードを追記し、footerの位置を調節した

### スクリーンショット
<!-- 以下にスクリーンショットを添付 -->
新規登録ページを例にしてBeforeとAfter
Before
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/5e72d107-4fc0-4d76-98c1-d2acc923b25b">

After
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/3a978dae-091c-4bcd-adc3-df755d1f4327">
