### PR TITLE
IndexController のテストを実装

### DIFF
--- a/src/main/java/com/tabisketch/controller/TopController.java
+++ b/src/main/java/com/tabisketch/controller/TopController.java
@@ -1,12 +1,14 @@
 package com.tabisketch.controller;
 
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping("/")
-public class IndexController {
+@Controller
+@RequestMapping("/top")
+public class TopController {
     @GetMapping
-    public String index() {
+    public String get() {
         return "index";
     }
 }

--- a/src/main/java/com/tabisketch/security/WebSecurityConfiguration.java
+++ b/src/main/java/com/tabisketch/security/WebSecurityConfiguration.java
@@ -15,7 +15,7 @@ public class WebSecurityConfiguration {
     public SecurityFilterChain securityFilterChain(final HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
                 .authorizeHttpRequests(a -> a
-                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/", "/top").permitAll()
                         .anyRequest().denyAll()
                 ).formLogin(a -> a
                         .loginPage("/login")

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    トップ画面
+</body>
+</html>

--- a/src/test/java/com/tabisketch/controller/IndexControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/IndexControllerTest.java
@@ -8,7 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@WebMvcTest(controllers = IndexController.class)
+@WebMvcTest(IndexController.class)
 public class IndexControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/tabisketch/controller/IndexControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/IndexControllerTest.java
@@ -1,0 +1,23 @@
+package com.tabisketch.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(controllers = IndexController.class)
+public class IndexControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser
+    public void 表示されるか() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/"))
+               .andExpect(MockMvcResultMatchers.status().isOk())
+               .andExpect(MockMvcResultMatchers.view().name("index"));
+    }
+}

--- a/src/test/java/com/tabisketch/controller/TopControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/TopControllerTest.java
@@ -8,7 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@WebMvcTest(controllers = TopController.class)
+@WebMvcTest(TopController.class)
 public class TopControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/tabisketch/controller/TopControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/TopControllerTest.java
@@ -1,0 +1,23 @@
+package com.tabisketch.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(controllers = TopController.class)
+public class TopControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser
+    public void 表示されるか() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/top"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("index"));
+    }
+}


### PR DESCRIPTION
## 概要
<!-- 以下にissueを記載 (close #xxx)-->
close https://github.com/saitokazumasa/tabisketch/issues/67

<!-- 以下にプルリクの内容を記載 -->
- IndexController を IndexController と TopController に分割
- IndexController と TopController  のテストを実装
- `/top` を permitAll() に追加
- `index.html` を空で作成

### スクリーンショット
<!-- 以下にスクリーンショットを添付 -->
特になし