### PR TITLE
テストのエラーハンドリングリファクタ&初期SQLデータ自動作成スクリプト追加

### DIFF
--- a/.run/sql/InsertExampleUser.sql
+++ b/.run/sql/InsertExampleUser.sql
@@ -1,2 +1,0 @@
-INSERT INTO users (mail, password)
-VALUES ('sample@example.com', 'password');

--- a/src/test/java/com/tabisketch/controller/AuthenticateMailControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/AuthenticateMailControllerTest.java
@@ -17,14 +17,9 @@ public class AuthenticateMailControllerTest {
     @ParameterizedTest
     @ValueSource(strings = {"a2e69add-9d95-4cf1-a59b-cedbb95dcd6b"})
     @WithMockUser
-    public void getが動作するか(final String token) {
-        try {
-            this.mockMvc.perform(MockMvcRequestBuilders.get("/mail/confirm/" + token))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.view().name("mail/confirm"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void getが動作するか(final String token) throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/mail/confirm/" + token))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("mail/confirm"));
     }
 }

--- a/src/test/java/com/tabisketch/controller/CreatePlanControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/CreatePlanControllerTest.java
@@ -15,14 +15,9 @@ public class CreatePlanControllerTest {
 
     @Test
     @WithMockUser
-    public void getが動作するか() {
-        try {
-            mockMvc.perform(MockMvcRequestBuilders.get("/plan/create"))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.view().name("plan/create"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void getが動作するか() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/plan/create"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("plan/create"));
     }
 }

--- a/src/test/java/com/tabisketch/controller/IndexControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/IndexControllerTest.java
@@ -15,14 +15,9 @@ public class IndexControllerTest {
 
     @Test
     @WithMockUser
-    public void getが動作するか() {
-        try {
-            mockMvc.perform(MockMvcRequestBuilders.get("/"))
-                    .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
-                    .andExpect(MockMvcResultMatchers.redirectedUrl("/top"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void getが動作するか() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/"))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(MockMvcResultMatchers.redirectedUrl("/top"));
     }
 }

--- a/src/test/java/com/tabisketch/controller/ListPlanControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/ListPlanControllerTest.java
@@ -15,14 +15,9 @@ public class ListPlanControllerTest {
 
     @Test
     @WithMockUser
-    public void getが動作するか() {
-        try {
-            mockMvc.perform(MockMvcRequestBuilders.get("/plan/list"))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.view().name("plan/list"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void getが動作するか() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/plan/list"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("plan/list"));
     }
 }

--- a/src/test/java/com/tabisketch/controller/RegisterControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/RegisterControllerTest.java
@@ -25,33 +25,23 @@ public class RegisterControllerTest {
 
     @Test
     @WithMockUser
-    public void getが動作するか() {
-        try {
-            this.mockMvc.perform(MockMvcRequestBuilders.get("/register"))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.view().name("register/index"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void getが動作するか() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/register"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("register/index"));
     }
 
     @ParameterizedTest
     @MethodSource("postが動作するかのテストデータ")
     @WithMockUser
-    public void postが動作するか(final RegisterForm registerForm) {
-        try {
-            this.mockMvc.perform(MockMvcRequestBuilders
-                            .post("/register")
-                            .flashAttr("registerForm", registerForm)
-                            .with(SecurityMockMvcRequestPostProcessors.csrf())
-                    ).andExpect(MockMvcResultMatchers.status().is3xxRedirection())
-                    .andExpect(MockMvcResultMatchers.model().hasNoErrors())
-                    .andExpect(MockMvcResultMatchers.redirectedUrl("/register/send"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void postが動作するか(final RegisterForm registerForm) throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/register")
+                        .flashAttr("registerForm", registerForm)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                ).andExpect(MockMvcResultMatchers.status().is3xxRedirection())
+                .andExpect(MockMvcResultMatchers.model().hasNoErrors())
+                .andExpect(MockMvcResultMatchers.redirectedUrl("/register/send"));
     }
 
     private static Stream<RegisterForm> postが動作するかのテストデータ() {
@@ -62,21 +52,16 @@ public class RegisterControllerTest {
     @ParameterizedTest
     @MethodSource("フォームがバリデーションエラーになるかのテストデータ")
     @WithMockUser
-    public void フォームがバリデーションエラーになるか(final RegisterForm registerForm) {
-        try {
-            this.mockMvc.perform(MockMvcRequestBuilders
-                            .post("/register")
-                            .flashAttr("registerForm", registerForm)
-                            .with(SecurityMockMvcRequestPostProcessors.csrf())
-                    ).andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.model().hasErrors())
-                    .andExpect(MockMvcResultMatchers.model().attributeExists("registerForm"))
-                    .andExpect(MockMvcResultMatchers.model().attribute("registerForm", registerForm))
-                    .andExpect(MockMvcResultMatchers.view().name("register/index"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void フォームがバリデーションエラーになるか(final RegisterForm registerForm) throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/register")
+                        .flashAttr("registerForm", registerForm)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                ).andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.model().hasErrors())
+                .andExpect(MockMvcResultMatchers.model().attributeExists("registerForm"))
+                .andExpect(MockMvcResultMatchers.model().attribute("registerForm", registerForm))
+                .andExpect(MockMvcResultMatchers.view().name("register/index"));
     }
 
     private static Stream<RegisterForm> フォームがバリデーションエラーになるかのテストデータ() {
@@ -90,14 +75,9 @@ public class RegisterControllerTest {
 
     @Test
     @WithMockUser
-    public void sendが動作するか() {
-        try {
-            this.mockMvc.perform(MockMvcRequestBuilders.get("/register/send"))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.view().name("register/send"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void sendが動作するか() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/register/send"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("register/send"));
     }
 }

--- a/src/test/java/com/tabisketch/controller/TopControllerTest.java
+++ b/src/test/java/com/tabisketch/controller/TopControllerTest.java
@@ -15,14 +15,9 @@ public class TopControllerTest {
 
     @Test
     @WithMockUser
-    public void getが動作するか() {
-        try {
-            mockMvc.perform(MockMvcRequestBuilders.get("/top"))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.view().name("top"));
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+    public void getが動作するか() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/top"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.view().name("top"));
     }
 }

--- a/src/test/java/com/tabisketch/mapper/MailAuthenticationTokensMapperTest.java
+++ b/src/test/java/com/tabisketch/mapper/MailAuthenticationTokensMapperTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -31,6 +32,10 @@ public class MailAuthenticationTokensMapperTest {
     }
 
     @ParameterizedTest
+    @Sql({
+            "classpath:/sql/CreateUser.sql",
+            "classpath:/sql/CreateMailAuthenticationToken.sql"
+    })
     @MethodSource("SELECTできるかのテストデータ")
     public void SELECTできるか(final UUID token) {
         final MailAuthenticationToken mailAuthenticationToken =
@@ -44,6 +49,10 @@ public class MailAuthenticationTokensMapperTest {
     }
 
     @ParameterizedTest
+    @Sql({
+            "classpath:/sql/CreateUser.sql",
+            "classpath:/sql/CreateMailAuthenticationToken.sql"
+    })
     @ValueSource(ints = {1})
     public void DELETEできるか(final int id) {
         final int result = this.mailAuthenticationTokensMapper.deleteById(id);

--- a/src/test/java/com/tabisketch/mapper/PlansMapperTest.java
+++ b/src/test/java/com/tabisketch/mapper/PlansMapperTest.java
@@ -16,6 +16,7 @@ public class PlansMapperTest {
     private IPlansMapper plansMapper;
 
     @ParameterizedTest
+    // TODO: 後ほどテストSQLデータを作成するスクリプトを追加する
     @ValueSource(ints = {1})
     public void SELECTできるか(final int userId) {
         final List<Plan> planList = plansMapper.selectByUserId(userId);

--- a/src/test/java/com/tabisketch/mapper/UsersMapperTest.java
+++ b/src/test/java/com/tabisketch/mapper/UsersMapperTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.util.stream.Stream;
 
@@ -17,6 +18,7 @@ public class UsersMapperTest {
     private IUsersMapper usersMapper;
 
     @ParameterizedTest
+    @Sql("classpath:/sql/CreateUser.sql")
     @ValueSource(strings = {"sample@example.com"})
     public void SELECTできるか(final String mail) {
         final User user = this.usersMapper.selectByMail(mail);

--- a/src/test/java/com/tabisketch/service/RegisterServiceTest.java
+++ b/src/test/java/com/tabisketch/service/RegisterServiceTest.java
@@ -23,19 +23,13 @@ public class RegisterServiceTest {
 
     @ParameterizedTest
     @MethodSource("動作するかのテストデータ")
-    public void 動作するか(final RegisterForm registerForm) {
+    public void 動作するか(final RegisterForm registerForm) throws MessagingException {
         final var registerService = new RegisterService(
                 this.usersMapper,
                 this.mailAuthenticationTokensMapper,
                 this.sendMailService
         );
-
-        try {
-            registerService.execute(registerForm);
-        } catch (final MessagingException e) {
-            System.out.println(e.getMessage());
-            assert false;
-        }
+        registerService.execute(registerForm);
     }
 
     private static Stream<RegisterForm> 動作するかのテストデータ() {

--- a/src/test/java/com/tabisketch/service/SendMailServiceTest.java
+++ b/src/test/java/com/tabisketch/service/SendMailServiceTest.java
@@ -16,14 +16,9 @@ public class SendMailServiceTest {
 
     @ParameterizedTest
     @MethodSource("動作するかのテストデータ")
-    public void 動作するか(final Mail mail) {
+    public void 動作するか(final Mail mail) throws MessagingException {
         // NOTE: アドレスエラーは検出されない
-        try {
-            sendMailService.execute(mail);
-            assert true;
-        } catch (final MessagingException e) {
-            assert false;
-        }
+        sendMailService.execute(mail);
     }
 
     private static Stream<Mail> 動作するかのテストデータ() {

--- a/src/test/resources/sql/CreateMailAuthenticationToken.sql
+++ b/src/test/resources/sql/CreateMailAuthenticationToken.sql
@@ -1,0 +1,2 @@
+INSERT INTO mail_authentication_tokens (id, token, user_id)
+VALUES (1, 'a2e69add-9d95-4cf1-a59b-cedbb95dcd6b', 1);

--- a/src/test/resources/sql/CreateUser.sql
+++ b/src/test/resources/sql/CreateUser.sql
@@ -1,0 +1,2 @@
+INSERT INTO users (id, mail, password)
+VALUES (1, 'sample@example.com', '$2a$10$FFbAunp0hfeWTCune.XqwO/P/61fqWlbruV/8wqzrhM3Pw0VuXxpa');


### PR DESCRIPTION
## 概要
<!-- 以下にissueを記載 (close #xxx)-->

<!-- 以下にプルリクの内容を記載 -->
**DB の中身が空なこと前提で、Mapperのテストを実行した際に初期のSQLデータが設定されるようにした**
- テストのエラーハンドリングをリファクタ
- 初期SQLデータ自動作成スクリプト追加

### スクリーンショット
<!-- 以下にスクリーンショットを添付 -->
なし