### PR TITLE
eslint を実行する github actions を追加

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,24 @@
+name: eslint
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        runner: [ubuntu-latest]
+        node: [20]
+    name: build on node ${{ matrix.node }} ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: npm ci
+        run: npm ci
+      - name: eslint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "- Java JDK 22.0.2\r - PostgreSQL 17",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint src/**/*.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## 概要
- プルリクが作成されたら、eslint を github actions で実行する仕組みを導入する

## プルリク対象
- #156 

## 関連する
- #152 

## 実装
- `npm run lint` で eslint が実行できるよに npm script を追加 04aa2411e37614f8f2492b32009f4a210211593e
- `npm run lint` を実行する github actions の設定ファイルを追加 c9fd0dc6ac4587b2f74c02ccad6dc52714834c15

### スクリーンショット
<!-- 以下にスクリーンショットを添付 -->
