### PR TITLE
[参考] tailwind.css を生成する github actions を追加する

### DIFF
--- a/.github/workflows/tailwindcss.yml
+++ b/.github/workflows/tailwindcss.yml
@@ -1,0 +1,24 @@
+name: tailwindcss
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        runner: [ubuntu-latest]
+        node: [22.13.1]
+    name: build tailwind.css on node ${{ matrix.node }} ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: npm ci
+        run: npm ci
+      - name: build tailwind.css
+        run: npm run tailwindcss

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint src/**/*.js",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "tailwindcss": "tailwindcss -i ./src/main/resources/static/css/input.css -o ./src/main/resources/static/css/tailwind.css",
     "docker:build": "docker compose -f docker/docker-compose.yml build",
     "docker:up": "docker compose -f docker/docker-compose.yml up -d",
     "docker:down": "docker compose -f docker/docker-compose.yml down -v"


### PR DESCRIPTION
## 概要

tailwindcss v4 のアップデートの不具合を github actions で検知できなかったため、
tailwind.css を生成する github actions を追加して回す

- `npm run tailwindcss` で tailwind.css を生成する npm script を追加
   あえて npx を使わないことで、 package.json に登録してある tailwindcss のバージョンを尊重する
- github actions で 上記 npm script を実行する