### PR TITLE
ci: dependabot設定にDockerパッケージエコシステムを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,10 @@ updates:
       interval: "daily"
       time: "07:30"
       timezone: "Asia/Tokyo"
+  - package-ecosystem: "docker"
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
## 概要

DependabotにDockerパッケージの更新を対象とする設定を追加しました。

例えば、

https://github.com/saitokazumasa3/tabisketch/blob/c36253d59038158b911ff4898f1c546352a3eb54/docker/app/Dockerfile#L2

の `22.13.1` の部分

https://github.com/saitokazumasa3/tabisketch/blob/c36253d59038158b911ff4898f1c546352a3eb54/docker/app/Dockerfile#L10

の `3.9.9-eclipse-temurin-22` の部分などのアップデートを自動でチェックするようになります。

更新スケジュールは他の設定と同様、毎日07:30 (Asia/Tokyo) です。


