### PR TITLE
正しいmarkdown書式で .md ファイルを記述する

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,17 @@
+name: markdown linter
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: lint markdown
+    steps:
+      - uses: actions/checkout@v4
+      - name: markdownlint-cli2-action
+        uses: DavidAnson/markdownlint-cli2-action@v9
+        with:
+          globs: |
+            README.md

--- a/README.md
+++ b/README.md
@@ -1,47 +1,57 @@
 # たびすけっち
 
-# 規則
-## ブランチ
+## 規則
+
+### ブランチ
 
 - main ... メインブランチ
 - release ... アプリリリースブランチ
 
-その他ブランチ名は [GitHub フロー](https://docs.github.com/ja/get-started/using-github/github-flow) に従い、変更内容に沿った名前にする。
+その他ブランチ名は [GitHub フロー](https://docs.github.com/ja/get-started/using-github/github-flow)
+に従い、変更内容に沿った名前にする。
 
 ## 用語
 
 - MailAddressAuthenticationToken -> MAAToken  
   メールアドレス認証トークン
 
-# 開発
-## 環境構築
+## 開発
+
+### 環境構築
+
 以下の手順をコマンドラインで実行する。
+
 1. 依存パッケージをインストール
-```shell
-npm install
-```
+
+   ```shell
+   npm install
+   ```
 
 2. `.env.example` を `.env` として複製、値を書き換え
 
 3. Dockerをビルド&起動
-```shell
-npm run docker:build
-npm run docker:up
-```
 
-## カスタムコマンド
+   ```shell
+   npm run docker:build
+   npm run docker:up
+   ```
+
+### カスタムコマンド
 
 ### Docker ビルド
+
 ```shell
 npm run docker:build
 ```
 
 ### Docker 起動
+
 ```shell
 npm run docker:up
 ```
 
 ### Docker 破棄
+
 ```shell
 npm run docker:down
 ```


### PR DESCRIPTION
## 概要
close #339 

現在の README.md は markdown書式を守っていないため、正しい markdown 書式に変更する
github actions で README.md を linter にかけるようにする


<!-- 以下にプルリクの内容を記載 -->

- README.md を 正しい markdown書式にする 87ef8babec49520dacab286a961842a79d3bf1c8
- github actions で markdown の linter を回す de4500f6a24091d0f0ff01d3945e0e7e4e17cabc

