### PR TITLE
[参考] playwright の E2E テストを、docker compose の環境で実行する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ build/
 
 ### Tailwind CSS ###
 **/src/main/**/css/tailwind.css
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ npm run docker:test
 ```shell
 npm run docker:down
 ```
+
+### Docker E2E テスト実行
+```shell
+npm run docker:e2e:run
+```

--- a/README.md
+++ b/README.md
@@ -53,5 +53,10 @@ npm run docker:down
 
 ### Docker E2E テスト実行
 ```shell
+# downすることでDBを初期化する
+npm run docker:e2e:down
+# app と postgresql を起動
+npm run docker:e2e:up
+# playwright でテスト実行
 npm run docker:e2e:run
 ```

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -1,0 +1,21 @@
+services:
+  app:
+    networks:
+      default:
+        aliases:
+          - app.local
+  playwright:
+    container_name: playwright
+    build:
+      context: ../
+      dockerfile: ./docker/e2e/Dockerfile
+    depends_on:
+      - app
+      - postgresql
+    env_file:
+      - ../.env
+    environment:
+      POSTGRES_HOST: postgresql
+    volumes:
+      - ../:/app
+    tty: true

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -1,5 +1,10 @@
 services:
+  postgresql:
+    container_name: postgresql-e2e
+    volumes:
+      - ../e2e/seeds/99-seeds.sql:/docker-entrypoint-initdb.d/99-seeds.sql
   app:
+    container_name: app-e2e
     networks:
       default:
         aliases:

--- a/docker/e2e/Dockerfile
+++ b/docker/e2e/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/playwright:v1.50.1-noble
+
+WORKDIR /app
+
+ENV SHELL=/bin/bash
+ENV NODE_ENV=development
+ENV IN_DOCKER=true
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+CMD ["npx", "playwright", "test"]

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+import { url } from "./settings";
+
+test('ログインすると旅行プラン一覧ページに進む', async ({ page }) => {
+  // ログインページにアクセスする
+  await page.goto(`${url}/login`)
+
+  // タイトルが正しいことを確認する
+  await expect(page).toHaveTitle('ログイン')
+
+  // ログインフォームに入力する
+  await page.fill('input[name="mailAddress"]', 'testuser@example.com')
+  await page.fill('input[name="password"]', 'testuser')
+
+  // ログインボタンをクリックする
+  await page.click('button[type="submit"]')
+
+  // ログイン後のページに遷移することを確認する
+  await expect(page).toHaveURL(`${url}/plan/list`)
+
+  // ログイン後のページのタイトルが正しいことを確認する
+  await expect(page).toHaveTitle('旅行プラン一覧')
+});

--- a/e2e/seeds/99-seeds.sql
+++ b/e2e/seeds/99-seeds.sql
@@ -1,0 +1,4 @@
+-- メール認証済みのテスト用ユーザーを追加
+-- mail_address: testuser@example.com
+-- password: testuser
+INSERT INTO public.users (id, mail_address, password, mail_address_authenticated) VALUES (1, 'testuser@example.com', '$2a$10$ROxsNdyPajVVcaJgcP07.e3ipaty122LyYIXHx0IYdcVZRShmOKeO', true);

--- a/e2e/settings.ts
+++ b/e2e/settings.ts
@@ -1,0 +1,1 @@
+export const url = process.env.IN_DOCKER ? 'http://app.local:8080' : 'http://localhost:8080';

--- a/e2e/top.spec.ts
+++ b/e2e/top.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { url } from './settings'
+
+test('リダイレクト', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(url);
+
+  // http://localhost:8080/top にリダイレクトされる
+  await expect(page).toHaveURL(`${url}/top`);
+});
+
+test('タイトル', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(`${url}/top`);
+
+  // タイトルタグが 'トップ' であることを確認する
+  await expect(page).toHaveTitle('トップ');
+});
+
+test('ログインのnavリンク', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(`${url}/top`);
+
+  // ログインリンクが header > nav > ul > li:nth-child(1) に表示されていることを確認する
+  const loginLink = page.locator('header > nav > ul > li:nth-child(1) > a'); // 'a'タグの通常セレクタを使用
+  await expect(loginLink).toHaveText('ログイン');
+});
+
+test('新規登録のnavリンク', async ({ page }) => {
+  // TOPページにアクセスする
+  await page.goto(`${url}/top`);
+
+  // 新規登録リンクが header > nav > ul > li:nth-child(2) 表示されていることを確認する
+  const registerLink = page.locator('header > nav > ul > li:nth-child(2) > a'); // 'a'タグの通常セレクタを使用
+  await expect(registerLink).toHaveText('新規登録');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "9.16.0",
         "eslint": "9.17.0",
         "globals": "15.14.0",
+        "playwright": "1.50.1",
         "tailwindcss": "3.4.17"
       }
     },
@@ -1784,6 +1785,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
       },
       "devDependencies": {
         "@eslint/js": "9.16.0",
+        "@playwright/test": "1.50.1",
+        "@types/node": "22.13.0",
         "eslint": "9.17.0",
         "globals": "15.14.0",
         "playwright": "1.50.1",
@@ -394,6 +396,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -474,6 +492,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
+      "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -2392,6 +2420,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "docker:build": "sh docker/bin/docker_compose_build.sh ./docker",
     "docker:up": "sh docker/bin/docker_compose_up.sh ./docker",
     "docker:test": "sh docker/bin/docker_compose_test.sh ./docker",
-    "docker:down": "sh docker/bin/docker_compose_down.sh ./docker"
+    "docker:down": "sh docker/bin/docker_compose_down.sh ./docker",
+    "docker:e2e:build": "docker compose -f ./docker/01-docker-compose.yml -f ./docker/docker-compose.e2e.yml build",
+    "docker:e2e:run": "docker compose -f ./docker/01-docker-compose.yml -f ./docker/docker-compose.e2e.yml run --rm playwright",
+    "docker:e2e:down": "docker compose -f ./docker/01-docker-compose.yml -f ./docker/docker-compose.e2e.yml down -v"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +21,7 @@
     "@eslint/js": "9.16.0",
     "eslint": "9.17.0",
     "globals": "15.14.0",
+    "playwright": "1.50.1",
     "tailwindcss": "3.4.17"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "license": "ISC",
   "devDependencies": {
     "@eslint/js": "9.16.0",
+    "@playwright/test": "1.50.1",
+    "@types/node": "22.13.0",
     "eslint": "9.17.0",
     "globals": "15.14.0",
     "playwright": "1.50.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "docker:test": "sh docker/bin/docker_compose_test.sh ./docker",
     "docker:down": "sh docker/bin/docker_compose_down.sh ./docker",
     "docker:e2e:build": "docker compose -f ./docker/01-docker-compose.yml -f ./docker/docker-compose.e2e.yml build",
+    "docker:e2e:up": "docker compose -f ./docker/01-docker-compose.yml -f ./docker/docker-compose.e2e.yml up postgresql app",
     "docker:e2e:run": "docker compose -f ./docker/01-docker-compose.yml -f ./docker/docker-compose.e2e.yml run --rm playwright",
     "docker:e2e:down": "docker compose -f ./docker/01-docker-compose.yml -f ./docker/docker-compose.e2e.yml down -v"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,81 @@
+// @ts-check
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});
+

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: 'line',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -78,4 +78,3 @@ export default defineConfig({
   //   reuseExistingServer: !process.env.CI,
   // },
 });
-


### PR DESCRIPTION
## 概要

- docker compose で playwright の E2E テストを実行する基本的なファイル構造等をコミット
- テストに利用する testuser をDBに追加する d4cb8cb5ed14d4d4636eebc469e2f60ff5067b60
- ブラウザを自動操縦して実際にログインする 71caa24ab3f989cb8f4707d606cc6a6118558862
