### PR TITLE
スマホ画面のメニュー表示修正

### DIFF
--- a/src/main/resources/static/js/header.js
+++ b/src/main/resources/static/js/header.js
@@ -1,13 +1,18 @@
 const tham = document.querySelector('.tham');
 const mobileMenu = document.getElementById('mobile-menu');
+const overlay = document.getElementById('overlay');
 
 tham.addEventListener('click', () => {
-    tham.classList.toggle('tham-active');
-    mobileMenu.classList.toggle('hidden');
+    tham.classList.toggle('tham-active'); // メニューを表示
+    mobileMenu.classList.toggle('hidden'); // ハンバーガーアイコンを非表示
+    document.body.classList.toggle('overflow-hidden'); // bodyのスクロールを不可に
+    overlay.classList.toggle('hidden'); // 背景の要素の色を非表示
 
     // ウィンドウのリサイズイベント
     window.addEventListener('resize', () => {
         mobileMenu.classList.add('hidden');  // メニューを非表示にする
         tham.classList.remove('tham-active'); // ハンバーガーアイコンを元の状態に戻す
+        document.body.classList.toggle('overflow-hidden'); // bodyのスクロールを可能に戻す
+        overlay.classList.toggle('hidden'); // 背景の要素に色を表示
     });
 });

--- a/src/main/resources/templates/fragment/header.html
+++ b/src/main/resources/templates/fragment/header.html
@@ -3,13 +3,13 @@
 <body>
 <th:block th:fragment="header">
     <header class="w-full">
-        <nav class="box-border border-2 h-14 sm:h-28 flex items-center justify-between px-3 whitespace-nowrap">
+        <nav class="box-border border-2 h-14 sm:h-28 flex items-center justify-between px-3 whitespace-nowrap z-50">
             <div class="flex items-center">
                 <img th:src="@{/images/icon.png}" alt="たびすけっちのアイコン" class="h-12 w-12">
                 <a th:href="@{/}" class="mx-3 sm:text-title font-extrabold text-xl">たびすけっち</a>
             </div>
             <!-- ハンバーガーメニュー (sm未満で表示) -->
-            <button class="tham tham-e-squeeze tham-w-6 sm:hidden">
+            <button class="tham tham-e-squeeze tham-w-6 sm:hidden z-40">
                 <div class="tham-box">
                     <div class="tham-inner"></div>
                 </div>
@@ -30,7 +30,8 @@
             </ul>
         </nav>
         <!-- ハンバーガーメニュー用のメニュー (sm未満で表示) -->
-        <ul class="fixed right-0 h-full w-1/2 bg-white flex-col border-l-2 border-b-2 text-center pt-4 space-y-10 hidden text-base" id="mobile-menu">
+        <ul class="fixed top-0 right-0 h-full w-1/2 bg-white flex-col border-l-2 border-b-2 text-center space-y-10 z-30 hidden text-base" id="mobile-menu">
+            <li class="mb-20"></li>
             <li sec:authorize="isAuthenticated()"><a th:href="@{/plan/list}">プラン一覧</a></li>
             <li sec:authorize="isAuthenticated()"><a th:href="@{/plan/create}">プラン作成</a></li>
             <li sec:authorize="isAuthenticated()"><a th:href="@{/user/edit}">アカウント編集</a></li>

--- a/src/main/resources/templates/fragment/header.html
+++ b/src/main/resources/templates/fragment/header.html
@@ -43,6 +43,7 @@
                 </form>
             </li>
         </ul>
+        <div class="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-20 hidden" id="overlay"></div>
     </header>
 </th:block>
 </body>


### PR DESCRIPTION
## 概要
スマホ画面のメニュー表示を修正

### 変更内容

<!-- 適宜スクリーンショットを添付 -->
ログイン前
![image](https://github.com/user-attachments/assets/2d5e6f74-5a09-40c3-8f32-97857b0963b3)
ログイン後
![image](https://github.com/user-attachments/assets/0bd2aab5-a3b5-4967-8325-424a8f06561f)


- [x] z-indexをつけて表示位置を修正
- [x] メニュー表示時にbody要素のスクロール不可に
- [x] 背景に色追加、divを重ねてるため下の要素のbuttonなども反応しない
