### PR TITLE
編集画面の表示のみ作成（plan/edit）

### DIFF
--- a/src/main/resources/templates/fragment/script.html
+++ b/src/main/resources/templates/fragment/script.html
@@ -21,9 +21,11 @@
             //     useFerry: true,
             //     maxWalkingTime: 1
             // };
+            // todo: 経路情報乗っける
             // initializeMaps(placeIds, travelModes, options);
             initializeMaps();
-            initAutoComplete();
+            // todo: autocomplete.jsが完成したら
+            // initAutoComplete();
             window.closePopup = function() {
                 openPopupMap(placeIds,travelModes,options);
             }

--- a/src/main/resources/templates/fragment/update-modal.html
+++ b/src/main/resources/templates/fragment/update-modal.html
@@ -19,9 +19,9 @@
     <div class="flex justify-center" id="startTransportationData">
         <span class="inline-flex justify-between items-center space-x-4 w-48">
             <!-- 移動手段のenumの比較 -->
-            <th:block th:if="*{departurePoint.transportation == T(com.tabisketch.constant.Transporation).DRIVE}" th:insert="~{fragment/svg :: car}"/>
-            <th:block th:if="*{departurePoint.transportation == T(com.tabisketch.constant.Transporation).BICYCLE}" th:insert="~{fragment/svg :: cycle}"/>
-            <th:block th:if="*{departurePoint.transportation == T(com.tabisketch.constant.Transporation).WALK}" th:insert="~{fragment/svg :: walk}"/>
+            <th:block th:if="*{departurePoint.transporation == T(com.tabisketch.constant.Transporation).DRIVE}" th:insert="~{fragment/svg :: car}"/>
+            <th:block th:if="*{departurePoint.transporation == T(com.tabisketch.constant.Transporation).BICYCLE}" th:insert="~{fragment/svg :: cycle}"/>
+            <th:block th:if="*{departurePoint.transporation == T(com.tabisketch.constant.Transporation).WALK}" th:insert="~{fragment/svg :: walk}"/>
 <!--            todo: 移動時間の表示 -->
 <!--            <span th:text="${departurePoint.toTravelTime}"></span>-->
         </span>
@@ -85,8 +85,8 @@
     <!-- 場所名、時間の表示 -->
     <button class="input text-center text-label max-w-md w-4/5 h-10 sm:h-12 flex justify-center items-center"
             data-modal-target="endUpdateModal" data-modal-toggle="endUpdateModal" id="endUpdateToggle" type="button">
-        <!-- todo: 時間の表示 th:textの追加 -->
-        <span class="text-[10px] sm:text-base">21:90</span>
+        <!-- todo: 到着時刻の表示 th:textの追加 -->
+<!--        <span class="text-[10px] sm:text-base">21:90</span>-->
         <span class="text-base sm:text-xl truncate ... px-2" th:text="*{destinationPoint.label}">終了地点を入力する</span>
     </button>
     <div aria-hidden="true"
@@ -108,8 +108,8 @@
                         <span class="sr-only">Close modal</span>
                     </button>
                 </div>
-                <!--  -->
-                <form class="p-4 sm:p-5" id="updateEndForm">
+                <!-- Modal Body -->
+                <div class="p-4 sm:p-5" id="updateEndForm">
                     <span id="updateEndError" class="text-danger text-sm mb-2 flex justify-center"></span>
                     <div class="space-y-4 w-full">
                         <input th:field="*{destinationPoint.placeId}" class="hidden" id="endUpdatePlaceId" name="endPlaceId" type="text"/>
@@ -122,7 +122,7 @@
                             <button class="button-primary" type="button">更新</button>
                         </div>
                     </div>
-                </form>
+                </div>
             </div>
         </div>
     </div>
@@ -137,24 +137,26 @@
                 th:id="'placesUpdateToggle' + ${stat.index}" type="button">
             <span class="block text-[10px] sm:text-base" th:id="'placeUpdateTimeSpan' + ${stat.index}" th:text="*{#temporals.format(waypointList[__${stat.index}__].preferredArrivalDatetime,'HH:mm')}"></span>
             <span class="flex-1 text-base sm:text-xl truncate ... px-2" th:id="'placeUpdateNameSpan' + ${stat.index}"
-                  th:text="*{waypoint[__${stat.index}__].label}">目的地を追加する</span>
+                  th:text="*{waypointList[__${stat.index}__].label}">目的地を追加する</span>
             <span class="flex items-end text-[8px] sm:text-xs">
-                <span class="block" th:text="${updatePlaceForm.budget==null ? '予算：－－－－円' : '予算：'+updatePlaceForm.budget+'円'}"></span>
+                <span class="block" th:if="*{waypointList[__${stat.index}__].budget}" th:text="*{'予算: ' + waypointList[__${stat.index}__].budget + '円'}"></span>
+                <span class="block" th:unless="*{waypointList[__${stat.index}__].budget}">予算: ----円</span>
             </span>
         </button>
+        <!-- 削除ボタン -->
         <button class="px-2" th:id="'modalDeleteBtn' + ${stat.index}">
             <th:block th:replace="~{fragment/svg :: close}"/>
         </button>
     </div>
     <!-- 移動手段・時間の表示 -->
-    <div class="flex justify-center" th:classappend="${isCreateRoute ? '' : 'hidden'}" th:id="${'placeTransportationData' + num}">
+    <div class="flex justify-center" th:id="${'placeTransportationData' + num}">
         <span class="inline-flex justify-between items-center space-x-4 w-48">
             <!-- 移動手段のenumの比較 -->
-            <th:block th:if="*{waypoint[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).DRIVE}" th:insert="~{fragment/svg :: car}"/>
-            <th:block th:if="*{waypoint[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).BICYCLE}" th:insert="~{fragment/svg :: cycle}"/>
-            <th:block th:if="*{waypoint[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).WALK}" th:insert="~{fragment/svg :: walk}"/>
+            <th:block th:if="*{waypointList[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).DRIVE}" th:insert="~{fragment/svg :: car}"/>
+            <th:block th:if="*{waypointList[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).BICYCLE}" th:insert="~{fragment/svg :: cycle}"/>
+            <th:block th:if="*{waypointList[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).WALK}" th:insert="~{fragment/svg :: walk}"/>
 <!--             todo: 移動時間の表示 -->
-<!--            <span th:text="${waypoint[__${stat.index}__]}"></span>-->
+<!--            <span th:text="*{waypointList[__${stat.index}__]}"></span>-->
         </span>
         <!-- todo: 移動手段の変更 selectedにしてもいいかも -->
         <!--       参考:https://flowbite.com/docs/forms/select/#select-input-example -->
@@ -183,24 +185,24 @@
                 <div class="p-4 sm:p-5" th:id="'updatePlaceForm'+${stat.index}">
                     <span th:id="'updatePlaceError'+${stat.index}" class="text-danger text-sm mb-2 flex justify-center"></span>
                     <div class="space-y-4 w-full">
-                        <input th:field="*{waypoint[__${stat.index}__].placeId}" th:id="'placeUpdatePlaceId'+${stat.index}" class="hidden" type="text"/>
-                        <input th:field="*{waypoint[__${stat.index}__].id}" th:id="'id'+${stat.index}" class="hidden" type="number">
+                        <input th:field="*{waypointList[__${stat.index}__].placeId}" th:id="'placeUpdatePlaceId'+${stat.index}" class="hidden" type="text"/>
+                        <input th:field="*{waypointList[__${stat.index}__].id}" th:id="'id'+${stat.index}" class="hidden" type="number">
                         <div>
                             <label class="block mb-2" th:for="'updatePlace'+${stat.index}">目的地</label>
-                            <input th:field="*{waypoint[__${stat.index}__].label}" class="w-full input focus:ring-0 bg-gray-100" th:id="'updatePlace'+${stat.index}" type="text" readonly/>
+                            <input th:field="*{waypointList[__${stat.index}__].label}" class="w-full input focus:ring-0 bg-gray-100" th:id="'updatePlace'+${stat.index}" type="text" readonly/>
                         </div>
                         <div class="flex items-center justify-between">
                             <div class="w-1/2 pr-3">
                                 <label class="block mb-2" th:for="'placeUpdateBudget' + ${stat.index}">予算</label>
                                 <div class="flex items-end">
-                                    <input th:field="*{waypoint[__${stat.index}__].budget}" th:id="'placeUpdateBudget'+${stat.index}" class="w-full input focus:ring-0" type="number"/>
+                                    <input th:field="*{waypointList[__${stat.index}__].budget}" th:id="'placeUpdateBudget'+${stat.index}" class="w-full input focus:ring-0" type="number"/>
                                     <span>円</span>
                                 </div>
                             </div>
                             <div class="w-1/2 pl-3">
                                 <label class="block mb-2" th:for="'updateStayTime' + ${stat.index}">滞在時間</label>
                                 <div class="flex items-end">
-                                    <input th:field="*{waypoint[__${stat.index}__].stayTime}" th:id="'updateStayTime' + ${stat.index}" class="w-full input focus:ring-0" type="number" min="1"/>
+                                    <input th:field="*{waypointList[__${stat.index}__].stayTime}" th:id="'updateStayTime' + ${stat.index}" class="w-full input focus:ring-0" type="number" min="1"/>
                                     <span>分</span>
                                 </div>
                             </div>

--- a/src/main/resources/templates/fragment/update-modal.html
+++ b/src/main/resources/templates/fragment/update-modal.html
@@ -1,281 +1,225 @@
-<!--<!DOCTYPE html>-->
-<!--<html lang="ja">-->
-<!--<head>-->
-<!--    <meta charset="UTF-8">-->
-<!--    <title>Title</title>-->
-<!--</head>-->
-<!--<body>-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
 
-<!--<th:block th:fragment="startUpdateToggle(updateStartForm, isCreateRoute)">-->
-<!--    &lt;!&ndash; Modal toggle &ndash;&gt;-->
-<!--    &lt;!&ndash; todo: 出発地点更新用Formを受け取って 場所名、開始時間の表示 &ndash;&gt;-->
-<!--    <button class="input text-center text-label max-w-md w-4/5 h-10 sm:h-12 flex justify-between items-center"-->
-<!--            data-modal-target="startUpdateModal" data-modal-toggle="startUpdateModal" id="startUpdateToggle" type="button">-->
-<!--        <span class="text-[10px] sm:text-base" th:text="${updateStartForm.startTime}"></span>-->
-<!--        <span class="flex-1 text-base sm:text-xl truncate ... px-2" th:text="${updateStartForm.name}">出発地点を入力する</span>-->
-<!--        <span></span>-->
-<!--    </button>-->
-<!--    &lt;!&ndash; todo: 経路生成済みの時は移動手段・時間の表示 &ndash;&gt;-->
-<!--    <div class="flex justify-center" th:classappend="${isCreateRoute ? '' : 'hidden'}" id="startTransportationData">-->
-<!--        <span class="inline-flex justify-between items-center space-x-4 w-48">-->
-<!--            &lt;!&ndash; todo: 移動手段のenumの比較 &ndash;&gt;-->
-<!--            <th:block th:if="${updateStartForm.toTransportation.name() == 'Driving'}" th:insert="~{fragment/svg :: car}"/>-->
-<!--            <th:block th:if="${updateStartForm.toTransportation.name() == 'Bicycling'}" th:insert="~{fragment/svg :: cycle}"/>-->
-<!--            <th:block th:if="${updateStartForm.toTransportation.name() == 'Transit'}" th:insert="~{fragment/svg :: train}"/>-->
-<!--            <th:block th:if="${updateStartForm.toTransportation.name() == 'Walking'}" th:insert="~{fragment/svg :: walk}"/>-->
-<!--            <span th:text="${updateStartForm.toTravelTime}"></span>-->
-<!--        </span>-->
-<!--        &lt;!&ndash; todo: 移動手段の変更 selectedにしてもいいかも &ndash;&gt;-->
-<!--        &lt;!&ndash;       参考:https://flowbite.com/docs/forms/select/#select-input-example &ndash;&gt;-->
-<!--    </div>-->
-<!--</th:block>-->
+<th:block th:fragment="startUpdate">
+    <!-- Modal toggle -->
+    <button class="input text-center text-label max-w-md w-4/5 h-10 sm:h-12 flex justify-between items-center"
+            data-modal-target="startUpdateModal" data-modal-toggle="startUpdateModal" id="startUpdateToggle" type="button">
+        <!-- 場所名、開始時間の表示 -->
+        <span class="text-[10px] sm:text-base" th:text="*{#temporals.format(departurePoint.departureDatetime, 'HH:mm')}"></span>
+        <span class="flex-1 text-base sm:text-xl truncate ... px-2" th:text="*{departurePoint.label}">出発地点を入力する</span>
+        <span></span>
+    </button>
+    <!-- 移動手段・時間の表示 -->
+    <div class="flex justify-center" id="startTransportationData">
+        <span class="inline-flex justify-between items-center space-x-4 w-48">
+            <!-- 移動手段のenumの比較 -->
+            <th:block th:if="*{departurePoint.transportation == T(com.tabisketch.constant.Transporation).DRIVE}" th:insert="~{fragment/svg :: car}"/>
+            <th:block th:if="*{departurePoint.transportation == T(com.tabisketch.constant.Transporation).BICYCLE}" th:insert="~{fragment/svg :: cycle}"/>
+            <th:block th:if="*{departurePoint.transportation == T(com.tabisketch.constant.Transporation).WALK}" th:insert="~{fragment/svg :: walk}"/>
+<!--            todo: 移動時間の表示 -->
+<!--            <span th:text="${departurePoint.toTravelTime}"></span>-->
+        </span>
+        <!-- todo: 移動手段の変更 selectedにしてもいいかも -->
+        <!--       参考:https://flowbite.com/docs/forms/select/#select-input-example -->
+    </div>
+    <!-- Main modal -->
+    <div aria-hidden="true"
+         class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full sm:inset-0 h-[calc(100%-1rem)] max-h-full text-label text-base"
+         id="startUpdateModal" tabindex="-1">
+        <div class="relative p-4 w-full max-w-md max-h-full">
+            <!-- Modal content -->
+            <div class="relative bg-white rounded-lg shadow">
+                <!-- Modal header -->
+                <div class="flex items-center justify-between p-4 sm:p-5 rounded-t border-b border-frame">
+                    <h3 class="text-xl text-black">
+                        出発地点を更新する
+                    </h3>
+                    <button class="end-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center"
+                            data-modal-hide="startUpdateModal" id="startUpdateClose" type="button">
+                        <svg aria-hidden="true" class="w-3 h-3" fill="none" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
+                            <path d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+                        </svg>
+                        <span class="sr-only">Close modal</span>
+                    </button>
+                </div>
+                <!-- Modal body -->
+                <!-- todo: 親htmlで呼び出すobjectの引数名を合わせる 出発地点を更新するUpdate○○Formを指定 -->
+                <div class="p-4 sm:p-5" id="updateStartForm">
+                    <span id="updateStartError" class="text-danger text-sm mb-2 flex justify-center"></span>
+                    <div class="space-y-4 w-full">
+                        <input th:field="*{departurePoint.placeId}" id="startUpdatePlaceId" class="hidden" type="text"/>
+                        <input th:field="*{departurePoint.id}" id="startUpdateId" class="hidden" type="number">
+                        <input th:field="*{departurePoint.transporation}" class="hidden" type="text">
+                        <div>
+                            <label class="block mb-2" for="startUpdatePlace">出発地点<span class="ml-2 text-sm text-danger">必須</span></label>
+                            <input th:field="*{departurePoint.label}" class="w-full input focus:ring-0" id="startUpdatePlace" name="startUpdatePlace" type="text"/>
+                        </div>
+                        <div class="w-1/2">
+                            <label class="block mb-2" for="startUpdateTime">出発日時<span class="ml-2 text-sm text-danger">必須</span></label>
+                            <div class="relative">
+                                <div class="absolute inset-y-0 end-0 top-0 flex items-center pe-3.5 pointer-events-none">
+                                    <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                        <path clip-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm11-4a1 1 0 1 0-2 0v4a1 1 0 0 0 .293.707l3 3a1 1 0 0 0 1.414-1.414L13 11.586V8Z" fill-rule="evenodd"/>
+                                    </svg>
+                                </div>
+                                <input th:field="*{departurePoint.departureDatetime}" class="w-full input focus:ring-0" id="startUpdateTime" type="datetime-local"/>
+                            </div>
+                        </div>
+                        <div class="flex justify-center">
+                            <button class="button-primary" type="button">更新</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</th:block>
 
-<!--<th:block th:fragment="startUpdateForm(updateStartForm)">-->
-<!--    &lt;!&ndash; Main modal &ndash;&gt;-->
-<!--    <div aria-hidden="true"-->
-<!--         class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full sm:inset-0 h-[calc(100%-1rem)] max-h-full text-label text-base"-->
-<!--         id="startUpdateModal" tabindex="-1">-->
-<!--        <div class="relative p-4 w-full max-w-md max-h-full">-->
-<!--            &lt;!&ndash; Modal content &ndash;&gt;-->
-<!--            <div class="relative bg-white rounded-lg shadow">-->
-<!--                &lt;!&ndash; Modal header &ndash;&gt;-->
-<!--                <div class="flex items-center justify-between p-4 sm:p-5 rounded-t border-b border-frame">-->
-<!--                    <h3 class="text-xl text-black">-->
-<!--                        出発地点を更新する-->
-<!--                    </h3>-->
-<!--                    <button class="end-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center"-->
-<!--                            data-modal-hide="startUpdateModal" id="startUpdateClose" type="button">-->
-<!--                        <svg aria-hidden="true" class="w-3 h-3" fill="none" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">-->
-<!--                            <path d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>-->
-<!--                        </svg>-->
-<!--                        <span class="sr-only">Close modal</span>-->
-<!--                    </button>-->
-<!--                </div>-->
-<!--                &lt;!&ndash; Modal body &ndash;&gt;-->
-<!--                &lt;!&ndash; todo: 親htmlで呼び出すobjectの引数名を合わせる 出発地点を更新するUpdate○○Formを指定 &ndash;&gt;-->
-<!--                <form class="p-4 sm:p-5" th:object="${updateStartForm}" id="updateStartForm">-->
-<!--                    <span id="updateStartError" class="text-danger text-sm mb-2 flex justify-center"></span>-->
-<!--                    <div class="space-y-4 w-full">-->
-<!--                        <input th:field="*{googlePlaceId}" id="startUpdatePlaceId" class="hidden" type="text"/>-->
-<!--                        <input th:field="*{latitude}" id="startUpdateLat" class="hidden" type="text"/>-->
-<!--                        <input th:field="*{longitude}" id="startUpdateLng" class="hidden" type="text"/>-->
-<!--                        <input th:field="*{id}" id="startUpdateId" class="hidden" type="number">-->
-<!--                        <input th:field="*{dayId}" id="startUpdateDayId" class="hidden" type="number"/>-->
-<!--                        <input th:field="*{budget}" id="startUpdateBudget" class="hidden" type="number"/>-->
-<!--                        <input th:field="*{endTime}" id="startUpdateEndTime" class="hidden" type="time"/>-->
-<!--                        <input th:field="*{desiredStartTime}" id="startUpdateDesiredStart" class="hidden" type="time"/>-->
-<!--                        <input th:field="*{desiredEndTime}" id="startUpdateDesiredEnd" class="hidden" type="time"/>-->
-<!--                        <input th:field="*{toPolyLine}" id="startUpdatePolyline" class="hidden" type="text"/>-->
-<!--                        <input th:field="*{toTravelTime}" id="startUpdateTravel" class="hidden" type="number"/>-->
-<!--                        <input th:field="*{toTransportation}" id="startUpdateTrans" class="hidden" type="text"/>-->
-<!--                        <div>-->
-<!--                            <label class="block mb-2" for="startUpdatePlace">出発地点<span class="ml-2 text-sm text-danger">必須</span></label>-->
-<!--                            <input th:field="*{name}" class="w-full input focus:ring-0" id="startUpdatePlace" name="startUpdatePlace" type="text"/>-->
-<!--                        </div>-->
-<!--                        <div class="w-1/2">-->
-<!--                            <label class="block mb-2" for="startUpdateTime">予定時間<span class="ml-2 text-sm text-danger">必須</span></label>-->
-<!--                            <div class="relative">-->
-<!--                                <div class="absolute inset-y-0 end-0 top-0 flex items-center pe-3.5 pointer-events-none">-->
-<!--                                    <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">-->
-<!--                                        <path clip-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm11-4a1 1 0 1 0-2 0v4a1 1 0 0 0 .293.707l3 3a1 1 0 0 0 1.414-1.414L13 11.586V8Z" fill-rule="evenodd"/>-->
-<!--                                    </svg>-->
-<!--                                </div>-->
-<!--                                <input th:field="*{startTime}" class="w-full input focus:ring-0" id="startUpdateTime" max="23:59" min="00:00" placeholder="&#45;&#45;:&#45;&#45;" type="time"/>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                        <div class="flex justify-center">-->
-<!--                            <button class="button-primary" type="submit">更新</button>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </form>-->
-<!--            </div>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</th:block>-->
+<th:block th:fragment="endUpdate">
+    <!-- 場所名、時間の表示 -->
+    <button class="input text-center text-label max-w-md w-4/5 h-10 sm:h-12 flex justify-center items-center"
+            data-modal-target="endUpdateModal" data-modal-toggle="endUpdateModal" id="endUpdateToggle" type="button">
+        <!-- todo: 時間の表示 th:textの追加 -->
+        <span class="text-[10px] sm:text-base">21:90</span>
+        <span class="text-base sm:text-xl truncate ... px-2" th:text="*{destinationPoint.label}">終了地点を入力する</span>
+    </button>
+    <div aria-hidden="true"
+         class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full sm:inset-0 h-[calc(100%-1rem)] max-h-full text-label text-base"
+         id="endUpdateModal" tabindex="-1">
+        <div class="relative p-4 w-full max-w-md max-h-full">
+            <!-- Modal content -->
+            <div class="relative bg-white rounded-lg shadow">
+                <!-- Modal header -->
+                <div class="flex items-center justify-between p-4 sm:p-5 rounded-t border-b border-frame">
+                    <h3 class="text-xl text-black">
+                        終了地点を更新する
+                    </h3>
+                    <button class="end-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center"
+                            data-modal-hide="endUpdateModal" id="endUpdateClose" type="button">
+                        <svg aria-hidden="true" class="w-3 h-3" fill="none" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
+                            <path d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+                        </svg>
+                        <span class="sr-only">Close modal</span>
+                    </button>
+                </div>
+                <!--  -->
+                <form class="p-4 sm:p-5" id="updateEndForm">
+                    <span id="updateEndError" class="text-danger text-sm mb-2 flex justify-center"></span>
+                    <div class="space-y-4 w-full">
+                        <input th:field="*{destinationPoint.placeId}" class="hidden" id="endUpdatePlaceId" name="endPlaceId" type="text"/>
+                        <input th:field="*{destinationPoint.id}" id="endUpdateId" class="hidden" type="number">
+                        <div>
+                            <label class="block mb-2" for="endUpdatePlace">終了地点<span class="ml-2 text-sm text-danger">必須</span></label>
+                            <input th:field="*{destinationPoint.label}" class="w-full input focus:ring-0" id="endUpdatePlace" type="text"/>
+                        </div>
+                        <div class="flex justify-center">
+                            <button class="button-primary" type="button">更新</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</th:block>
 
-<!--<th:block th:fragment="endUpdateToggle(updateEndForm)">-->
-<!--    &lt;!&ndash; todo: 終了地点更新Formを受け取って、場所名、時間の表示 &ndash;&gt;-->
-<!--    <button class="input text-center text-label max-w-md w-4/5 h-10 sm:h-12 flex justify-center items-center"-->
-<!--            data-modal-target="endUpdateModal" data-modal-toggle="endUpdateModal" id="endUpdateToggle" type="button">-->
-<!--        <span class="text-[10px] sm:text-base" th:text="${updateEndForm.endTime}"></span>-->
-<!--        <span class="text-base sm:text-xl truncate ... px-2" th:text="${updateEndForm.name}">終了地点を入力する</span>-->
-<!--    </button>-->
-<!--</th:block>-->
-
-<!--<th:block th:fragment="endUpdateForm(updateEndForm)">-->
-<!--    <div aria-hidden="true"-->
-<!--         class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full sm:inset-0 h-[calc(100%-1rem)] max-h-full text-label text-base"-->
-<!--         id="endUpdateModal" tabindex="-1">-->
-<!--        <div class="relative p-4 w-full max-w-md max-h-full">-->
-<!--            &lt;!&ndash; Modal content &ndash;&gt;-->
-<!--            <div class="relative bg-white rounded-lg shadow">-->
-<!--                &lt;!&ndash; Modal header &ndash;&gt;-->
-<!--                <div class="flex items-center justify-between p-4 sm:p-5 rounded-t border-b border-frame">-->
-<!--                    <h3 class="text-xl text-black">-->
-<!--                        終了地点を更新する-->
-<!--                    </h3>-->
-<!--                    <button class="end-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center"-->
-<!--                            data-modal-hide="endUpdateModal" id="endUpdateClose" type="button">-->
-<!--                        <svg aria-hidden="true" class="w-3 h-3" fill="none" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">-->
-<!--                            <path d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>-->
-<!--                        </svg>-->
-<!--                        <span class="sr-only">Close modal</span>-->
-<!--                    </button>-->
-<!--                </div>-->
-<!--                &lt;!&ndash; Modal body &ndash;&gt;-->
-<!--                &lt;!&ndash; todo: 親htmlで呼び出すobjectの引数名を合わせ 終了地点を更新するUpdate○○Formを指定 &ndash;&gt;-->
-<!--                <form class="p-4 sm:p-5" th:object="${updateEndForm}" id="updateEndForm">-->
-<!--                    <span id="updateEndError" class="text-danger text-sm mb-2 flex justify-center"></span>-->
-<!--                    <div class="space-y-4 w-full">-->
-<!--                        <input th:field="*{googlePlaceId}" class="hidden" id="endUpdatePlaceId" name="endPlaceId" type="text"/>-->
-<!--                        <input th:field="*{latitude}" class="hidden" id="endUpdateLat" type="text"/>-->
-<!--                        <input th:field="*{longitude}" class="hidden" id="endUpdateLng" type="text"/>-->
-<!--                        <input th:field="*{id}" id="endUpdateId" class="hidden" type="number">-->
-<!--                        <input th:field="*{dayId}" class="hidden" type="number"/>-->
-<!--                        <input th:field="*{budget}" class="hidden" type="number"/>-->
-<!--                        <input th:field="*{startTime}" class="hidden" type="time"/>-->
-<!--                        <input th:field="*{endTime}" class="hidden" type="time"/>-->
-<!--                        <input th:field="*{desiredStartTime}" class="hidden" type="time"/>-->
-<!--                        <input th:field="*{desiredEndTime}" class="hidden" type="time"/>-->
-<!--                        <input th:field="*{toPolyLine}" class="hidden" type="text"/>-->
-<!--                        <input th:field="*{toTravelTime}" class="hidden" type="number"/>-->
-<!--                        <input th:field="*{toTransportation}" class="hidden" type="text"/>-->
-<!--                        <div>-->
-<!--                            <label class="block mb-2" for="endUpdatePlace">終了地点<span class="ml-2 text-sm text-danger">必須</span></label>-->
-<!--                            <input th:field="*{name}" class="w-full input focus:ring-0" id="endUpdatePlace" type="text"/>-->
-<!--                        </div>-->
-<!--                        <div class="flex justify-center">-->
-<!--                            <button class="button-primary" type="submit">更新</button>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </form>-->
-<!--            </div>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</th:block>-->
-
-<!--<th:block th:fragment="placesUpdateToggle(num, updatePlaceForm, isCreateRoute)">-->
-<!--    <div class="flex items-center">-->
-<!--        &lt;!&ndash; Modal toggle &ndash;&gt;-->
-<!--        &lt;!&ndash; todo: 目的地更新用Formを受け取って 場所名、開始時間～終了時間、予算の表示 &ndash;&gt;-->
-<!--        <button class="input text-center text-label max-w-md w-4/5 flex justify-between items-center h-10 sm:h-12"-->
-<!--                th:data-modal-target="'placesUpdateModal' + ${num}" th:data-modal-toggle="'placesUpdateModal' + ${num}"-->
-<!--                th:id="'placesUpdateToggle' + ${num}" type="button">-->
-<!--            <span class="block text-[10px] sm:text-base" th:id="'placeUpdateTimeSpan' + ${num}" th:text="${updatePlaceForm.startTime + '~' + updatePlaceForm.endTime}"></span>-->
-<!--            <span class="flex-1 text-base sm:text-xl truncate ... px-2" th:id="'placeUpdateNameSpan' + ${num}"-->
-<!--                  th:text="${updatePlaceForm.name}">目的地を追加する</span>-->
-<!--            <span class="flex items-end text-[8px] sm:text-xs">-->
-<!--                <span class="block" th:text="${updatePlaceForm.budget==null ? '予算：－－－－円' : '予算：'+updatePlaceForm.budget+'円'}"></span>-->
-<!--            </span>-->
-<!--        </button>-->
-<!--        <button class="px-2" th:id="'modalDeleteBtn' + ${num}">-->
-<!--            <th:block th:replace="~{fragment/svg :: close}"/>-->
-<!--        </button>-->
-<!--    </div>-->
-<!--    &lt;!&ndash; 経路生成後に表示 &ndash;&gt;-->
-<!--    &lt;!&ndash; todo: 経路生成済みの時は移動手段・時間の表示 &ndash;&gt;-->
-<!--    <div class="flex justify-center" th:classappend="${isCreateRoute ? '' : 'hidden'}" th:id="${'placeTransportationData' + num}">-->
-<!--        <span class="inline-flex justify-between items-center space-x-4 w-48">-->
-<!--            &lt;!&ndash; todo: 移動手段のenumの比較 &ndash;&gt;-->
-<!--            <th:block th:if="${updatePlaceForm.toTransportation.name() == 'Driving'}" th:insert="~{fragment/svg :: car}"/>-->
-<!--            <th:block th:if="${updatePlaceForm.toTransportation.name() == 'Bicycling'}" th:insert="~{fragment/svg :: cycle}"/>-->
-<!--            <th:block th:if="${updatePlaceForm.toTransportation.name() == 'Transit'}" th:insert="~{fragment/svg :: train}"/>-->
-<!--            <th:block th:if="${updatePlaceForm.toTransportation.name() == 'Walking'}" th:insert="~{fragment/svg :: walk}"/>-->
-<!--            <span th:text="${updatePlaceForm.toTravelTime}"></span>-->
-<!--        </span>-->
-<!--        &lt;!&ndash; todo: 移動手段の変更 selectedにしてもいいかも &ndash;&gt;-->
-<!--        &lt;!&ndash;       参考:https://flowbite.com/docs/forms/select/#select-input-example &ndash;&gt;-->
-<!--    </div>-->
-<!--</th:block>-->
-
-<!--<th:block th:fragment="placesUpdateForm(num, updatePlaceForm)">-->
-<!--    &lt;!&ndash; Main modal &ndash;&gt;-->
-<!--    <div aria-hidden="true"-->
-<!--         class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full sm:inset-0 h-[calc(100%-1rem)] max-h-full text-label text-base"-->
-<!--         th:id="'placesUpdateModal'+${num}" tabindex="-1">-->
-<!--        <div class="relative p-4 w-full max-w-md max-h-full">-->
-<!--            &lt;!&ndash; Modal content &ndash;&gt;-->
-<!--            <div class="relative bg-white rounded-lg shadow">-->
-<!--                &lt;!&ndash; Modal header &ndash;&gt;-->
-<!--                <div class="flex items-center justify-between p-4 sm:p-5 rounded-t border-b border-frame">-->
-<!--                    <h3 class="text-xl text-black">-->
-<!--                        目的地を更新する-->
-<!--                    </h3>-->
-<!--                    <button class="end-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center"-->
-<!--                            th:data-modal-hide="'placesUpdateModal'+${num}" th:id="'placesUpdateClose'+${num}" type="button">-->
-<!--                        <svg aria-hidden="true" class="w-3 h-3" fill="none" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">-->
-<!--                            <path d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>-->
-<!--                        </svg>-->
-<!--                        <span class="sr-only">Close modal</span>-->
-<!--                    </button>-->
-<!--                </div>-->
-<!--                &lt;!&ndash; Modal body &ndash;&gt;-->
-<!--                &lt;!&ndash; todo: 親htmlで呼び出すobjectの引数名を合わせる 目的地を更新するUpdate○○Formを指定 &ndash;&gt;-->
-<!--                <form class="p-4 sm:p-5" th:id="'updatePlaceForm'+${num}">-->
-<!--                    <span th:id="'updatePlaceError'+${num}" class="text-danger text-sm mb-2 flex justify-center"></span>-->
-<!--                    <div class="space-y-4 w-full">-->
-<!--                        &lt;!&ndash; todo: オブジェクトとfieldを合わせる &ndash;&gt;-->
-<!--                        <input name="googlePlaceId" th:value="${updatePlaceForm.googlePlaceId}" th:id="'placeUpdatePlaceId'+${num}" class="hidden" type="text"/>-->
-<!--                        <input name="latitude" th:value="${updatePlaceForm.latitude}" th:id="'placeUpdateLat'+${num}" class="hidden" type="text"/>-->
-<!--                        <input name="longitude" th:value="${updatePlaceForm.longitude}" th:id="'placeUpdateLng'+${num}" class="hidden" type="text"/>-->
-<!--                        <input th:value="${updatePlaceForm.id}" th:id="'id'+${num}" class="hidden" type="number">-->
-<!--                        <input name="dayId" th:value="${updatePlaceForm.dayId}" class="hidden" type="number"/>-->
-<!--                        <input name="startTime" th:value="${updatePlaceForm.startTime}" th:id="'placeUpdateStartTime'+${num}" class="hidden" type="time"/>-->
-<!--                        <input name="endTime" th:value="${updatePlaceForm.endTime}" th:id="'placeUpdateEndTime'+${num}" class="hidden" type="time"/>-->
-<!--                        <input name="toPolyLine" th:value="${updatePlaceForm.toPolyLine}" class="hidden" type="text"/>-->
-<!--                        <input name="toTravelTime" th:value="${updatePlaceForm.toTravelTime}" class="hidden" type="number"/>-->
-<!--                        <input name="toTransportation" th:value="${updatePlaceForm.toTransportation}" class="hidden" type="text"/>-->
-<!--                        <div>-->
-<!--                            <label class="block mb-2" th:for="'updatePlace'+${num}">目的地<span class="ml-2 text-sm text-danger">必須</span></label>-->
-<!--                            <input th:value="${updatePlaceForm.name}" class="w-full input focus:ring-0 bg-gray-100" th:id="'updatePlace'+${num}" th:name="'updatePlace'+${num}" type="text" disabled/>-->
-<!--                        </div>-->
-<!--                        <div class="flex items-center justify-between">-->
-<!--                            <div class="w-1/2 pr-3">-->
-<!--                                <label class="block mb-2" th:for="'placeUpdateBudget' + ${num}">予算</label>-->
-<!--                                <div class="flex items-end">-->
-<!--                                    <input name="budget" th:value="${updatePlaceForm.budget}" th:id="'placeUpdateBudget'+${num}" class="w-full input focus:ring-0" th:name="'placeUpdateBudget' + ${num}" type="number"/>-->
-<!--                                    <span>円</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                            <div class="w-1/2 pl-3">-->
-<!--                                <label class="block mb-2" th:for="'updateStayTime' + ${num}">滞在時間</label>-->
-<!--                                <div class="flex items-end">-->
-<!--                                    <input class="w-full input focus:ring-0" th:id="'updateStayTime' + ${num}" th:name="'updateStayTime' + ${num}" type="number" min="1"/>-->
-<!--                                    <span>分</span>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                        <div>-->
-<!--                            <label class="block" th:for="'placeUpdateDesiredStart' + ${num}">希望時間</label>-->
-<!--                            <p class="text-sm mb-2">入力された時刻の範囲内で目的地に向かうことが出来ます</p>-->
-<!--                            <div class="flex items-center justify-between">-->
-<!--                                <div class="relative w-1/2">-->
-<!--                                    <div class="absolute inset-y-0 end-0 top-0 flex items-center pe-3.5 pointer-events-none">-->
-<!--                                        <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">-->
-<!--                                            <path clip-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm11-4a1 1 0 1 0-2 0v4a1 1 0 0 0 .293.707l3 3a1 1 0 0 0 1.414-1.414L13 11.586V8Z" fill-rule="evenodd"/>-->
-<!--                                        </svg>-->
-<!--                                    </div>-->
-<!--                                    <input name="desiredStartTime" th:value="${updatePlaceForm.desiredStartTime}" class="w-full input focus:ring-0" max="23:59" min="00:00" placeholder="&#45;&#45;:&#45;&#45;" th:id="'placeUpdateDesiredStart' + ${num}" th:name="'placeUpdateDesiredStart' + ${num}" type="time"/>-->
-<!--                                </div>-->
-<!--                                <span class="pr-3 pl-3">～</span>-->
-<!--                                <div class="relative w-1/2">-->
-<!--                                    <div class="absolute inset-y-0 end-0 top-0 flex items-center pe-3.5 pointer-events-none">-->
-<!--                                        <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">-->
-<!--                                            <path clip-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm11-4a1 1 0 1 0-2 0v4a1 1 0 0 0 .293.707l3 3a1 1 0 0 0 1.414-1.414L13 11.586V8Z" fill-rule="evenodd"/>-->
-<!--                                        </svg>-->
-<!--                                    </div>-->
-<!--                                    <input name="desiredEndTime" th:value="${updatePlaceForm.desiredEndTime}" class="w-full input focus:ring-0" max="23:59" min="00:00" placeholder="&#45;&#45;:&#45;&#45;" th:id="'placeUpdateDesiredEnd' + ${num}" th:name="'placeUpdateDesiredEnd' + ${num}" type="time"/>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                        <div class="flex justify-center">-->
-<!--                            <button class="button-primary" type="submit">更新</button>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </form>-->
-<!--            </div>-->
-<!--        </div>-->
-<!--    </div>-->
-<!--</th:block>-->
-<!--</body>-->
-<!--</html>-->
+<th:block th:fragment="placesUpdate">
+    <div class="flex items-center">
+        <!-- Modal toggle -->
+        <!-- todo: 目的地更新用Formを受け取って 場所名、開始時間～終了時間、予算の表示 -->
+        <button class="input text-center text-label max-w-md w-4/5 flex justify-between items-center h-10 sm:h-12"
+                th:data-modal-target="'placesUpdateModal' + ${stat.index}" th:data-modal-toggle="'placesUpdateModal' + ${stat.index}"
+                th:id="'placesUpdateToggle' + ${stat.index}" type="button">
+            <span class="block text-[10px] sm:text-base" th:id="'placeUpdateTimeSpan' + ${stat.index}" th:text="*{#temporals.format(waypointList[__${stat.index}__].preferredArrivalDatetime,'HH:mm')}"></span>
+            <span class="flex-1 text-base sm:text-xl truncate ... px-2" th:id="'placeUpdateNameSpan' + ${stat.index}"
+                  th:text="*{waypoint[__${stat.index}__].label}">目的地を追加する</span>
+            <span class="flex items-end text-[8px] sm:text-xs">
+                <span class="block" th:text="${updatePlaceForm.budget==null ? '予算：－－－－円' : '予算：'+updatePlaceForm.budget+'円'}"></span>
+            </span>
+        </button>
+        <button class="px-2" th:id="'modalDeleteBtn' + ${stat.index}">
+            <th:block th:replace="~{fragment/svg :: close}"/>
+        </button>
+    </div>
+    <!-- 移動手段・時間の表示 -->
+    <div class="flex justify-center" th:classappend="${isCreateRoute ? '' : 'hidden'}" th:id="${'placeTransportationData' + num}">
+        <span class="inline-flex justify-between items-center space-x-4 w-48">
+            <!-- 移動手段のenumの比較 -->
+            <th:block th:if="*{waypoint[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).DRIVE}" th:insert="~{fragment/svg :: car}"/>
+            <th:block th:if="*{waypoint[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).BICYCLE}" th:insert="~{fragment/svg :: cycle}"/>
+            <th:block th:if="*{waypoint[__${stat.index}__].transporation == T(com.tabisketch.constant.Transporation).WALK}" th:insert="~{fragment/svg :: walk}"/>
+<!--             todo: 移動時間の表示 -->
+<!--            <span th:text="${waypoint[__${stat.index}__]}"></span>-->
+        </span>
+        <!-- todo: 移動手段の変更 selectedにしてもいいかも -->
+        <!--       参考:https://flowbite.com/docs/forms/select/#select-input-example -->
+    </div>
+    <!-- Main modal -->
+    <div aria-hidden="true"
+         class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full sm:inset-0 h-[calc(100%-1rem)] max-h-full text-label text-base"
+         th:id="'placesUpdateModal'+${stat.index}" tabindex="-1">
+        <div class="relative p-4 w-full max-w-md max-h-full">
+            <!-- Modal content -->
+            <div class="relative bg-white rounded-lg shadow">
+                <!-- Modal header -->
+                <div class="flex items-center justify-between p-4 sm:p-5 rounded-t border-b border-frame">
+                    <h3 class="text-xl text-black">
+                        目的地を更新する
+                    </h3>
+                    <button class="end-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center"
+                            th:data-modal-hide="'placesUpdateModal'+${stat.index}" th:id="'placesUpdateClose'+${stat.index}" type="button">
+                        <svg aria-hidden="true" class="w-3 h-3" fill="none" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
+                            <path d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+                        </svg>
+                        <span class="sr-only">Close modal</span>
+                    </button>
+                </div>
+                <!-- Modal body -->
+                <div class="p-4 sm:p-5" th:id="'updatePlaceForm'+${stat.index}">
+                    <span th:id="'updatePlaceError'+${stat.index}" class="text-danger text-sm mb-2 flex justify-center"></span>
+                    <div class="space-y-4 w-full">
+                        <input th:field="*{waypoint[__${stat.index}__].placeId}" th:id="'placeUpdatePlaceId'+${stat.index}" class="hidden" type="text"/>
+                        <input th:field="*{waypoint[__${stat.index}__].id}" th:id="'id'+${stat.index}" class="hidden" type="number">
+                        <div>
+                            <label class="block mb-2" th:for="'updatePlace'+${stat.index}">目的地</label>
+                            <input th:field="*{waypoint[__${stat.index}__].label}" class="w-full input focus:ring-0 bg-gray-100" th:id="'updatePlace'+${stat.index}" type="text" readonly/>
+                        </div>
+                        <div class="flex items-center justify-between">
+                            <div class="w-1/2 pr-3">
+                                <label class="block mb-2" th:for="'placeUpdateBudget' + ${stat.index}">予算</label>
+                                <div class="flex items-end">
+                                    <input th:field="*{waypoint[__${stat.index}__].budget}" th:id="'placeUpdateBudget'+${stat.index}" class="w-full input focus:ring-0" type="number"/>
+                                    <span>円</span>
+                                </div>
+                            </div>
+                            <div class="w-1/2 pl-3">
+                                <label class="block mb-2" th:for="'updateStayTime' + ${stat.index}">滞在時間</label>
+                                <div class="flex items-end">
+                                    <input th:field="*{waypoint[__${stat.index}__].stayTime}" th:id="'updateStayTime' + ${stat.index}" class="w-full input focus:ring-0" type="number" min="1"/>
+                                    <span>分</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <div>
+                                <label class="block" th:for="'preferredArrivalDatetime' + ${stat.index}">希望到着日時</label>
+                                <p class="text-sm mb-2">指定した時間に到着するように経路を生成します。</p>
+                                <input th:field="*{waypointList[__${stat.index}__].preferredArrivalDatetime}" class="w-full input focus:ring-0" th:id="'updatePlaceDatetime' + ${stat.index}" type="datetime-local">
+                            </div>
+                        </div>
+                        <div class="flex justify-center">
+                            <button class="button-primary" type="button">更新</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/plan/edit.html
+++ b/src/main/resources/templates/plan/edit.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="ja">
+<th:block th:replace="~{fragment/head :: head(プラン作成)}"/>
+<body class="flex flex-col min-h-screen">
+<th:block th:replace="~{fragment/header :: header}"/>
+<main class="flex flex-col items-center flex-grow">
+    <div class="w-full">
+        <div id="popup"
+             class="hidden sm:hidden fixed inset-0 z-50 items-center justify-center bg-black bg-opacity-50"
+             onclick="closePopup()">
+            <div class="relative w-4/5 h-4/5 bg-white shadow-lg rounded-md"
+                 onclick="event.stopPropagation()">
+                <div id="sp-map" class="w-full h-full p-4"></div>
+            </div>
+        </div>
+        <!-- th:actionを設定 -->
+        <form th:action="@{/plan/edit/__${editPlanForm.uuid}__}" method="post">
+            <div th:object="${editPlanForm}">
+                <input type="hidden" th:field="*{uuid}">
+                <input type="hidden" th:field="*{editable}">
+                <input type="hidden" th:field="*{publiclyViewable}">
+                <div class="flex flex-col">
+                    <label class="text-center bg-red-50 flex justify-center items-center w-full" style="aspect-ratio: 5/1">
+                        <!-- カバー画像編集のpopup追加 editPlanForm.thumbnail 使う  -->
+                        <th:block th:replace="~{fragment/popup :: cover-image(*{thumbnailPath})}"/>
+                    </label>
+                    <div class="flex">
+                        <span class="sm:hidden inline-block h-12 w-12 my-auto ml-8"></span>
+                        <div class="sm:border-b-2 border-b w-1/2 text-center mx-auto my-10">
+                            <label>
+                                <input type="text" th:field="*{title}" placeholder="タイトルを入力してください" class="w-full sm:text-3xl text-xl text-center border-0">
+                            </label>
+                        </div>
+                        <button onclick="openPopup()" class="sm:hidden inline-block h-12 w-12 my-auto mr-8 cursor-pointer">
+                            <th:block th:replace="~{fragment/svg :: map}"/>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="mx-10 flex">
+                <section class="sm:w-1/2 w-full">
+                    <!-- 日付の表示 -->
+                    <div class="flex items-end space-x-0 pb-[0.625rem] border-b-2 mt-6">
+                        <!-- 日付表示する為に planIdが一致する waypoint_listsの行数を 仮:${travelDays}に入れて渡す -->
+                        <div th:each="index : ${#numbers.sequence(1, travelDays)}">
+                            <!-- todo: selectedDayにはパラメータのdayを入れる -->
+                            <a th:href="@{/plan/edit/__${editPlanForm.uuid}__(day=__${index}__)}"
+                               th:classappend="${index == selectedDay} ? 'pt-5 pb-3 sm:px-6 lg:px-12 px-8 bg-green-600 text-white text-lg h-12' : 'pt-3 pb-3 sm:px-4 lg:px-10 px-6 bg-green-400 text-white'"
+                               class="rounded-t-md text-center items-center cursor-pointer">
+                                <span th:text="${index} + '日目'"></span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- 各種地点の表示 -->
+                    <div class="flex flex-col mt-6 mb-10" th:object="${editWaypointListForm}">
+                        <!-- 出発地点 -->
+                        <div class="mb-6">
+                            <p class="mb-2 sm:text-lg text-base">出発地点</p>
+                            <th:block th:replace="~{fragment/update-modal :: startUpdate}"/>
+                        </div>
+                        <!-- 目的地 独自クラス「addPlaces」を取得して目的地追加ボタンを追加表示する -->
+                        <div class="mb-6">
+                            <p class="mb-2 sm:text-lg text-base">目的地</p>
+                            <th:block th:each="waypoint, stat : *{waypointList}">
+                                <th:block th:replace="~{fragment/update-modal :: placesUpdate}"/>
+                            </th:block>
+                        </div>
+                        <!-- 終了地点 -->
+                        <div class="mb-6">
+                            <p class="mb-2 sm:text-lg text-base">終了地点</p>
+                            <!-- 終了地点が入力済みかで表示変更 -->
+                            <th:block th:replace="~{fragment/update-modal :: endUpdate}"/>
+                        </div>
+                        <!-- 経路生成後の目的地追加表示 -->
+                        <div class="addPlaces">
+                            <th:block th:replace="~{fragment/modal :: places}"/>
+                        </div>
+                        <!-- おすすめ目的地のセクション　一旦コメント化-->
+<!--                        <section class="pt-10">-->
+<!--                            <details open class="p-4 group overflow-hidden transition-[max-height] duration-500">-->
+<!--                                <summary class="sm:text-xl text-lg cursor-pointer font-semibold marker:text-transparent group-open:before:rotate-90  before:origin-center relative before:w-[18px] before:h-[18px] before:transition-transform before:duration-200 before:-left-1 before:top-2/4 before:-translate-y-2/4 before:absolute before:bg-no-repeat before:bg-[length:18px_18px] before:bg-center before:bg-[url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20class%3D%22h-6%20w-6%22%20fill%3D%22none%22%20viewBox%3D%220%200%2024%2024%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%3E%0A%20%20%3Cpath%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20d%3D%22M9%205l7%207-7%207%22%20%2F%3E%0A%3C%2Fsvg%3E')]">-->
+<!--                                    おすすめ目的地を追加-->
+<!--                                </summary>-->
+<!--                                <hr class="my-2 scale-x-150"/>-->
+<!--                                &lt;!&ndash; おすすめ目的地のリストがない時 &ndash;&gt;-->
+<!--                                &lt;!&ndash; おすすめ目的地の目的地作成Formリスト 仮:${recommendList} 空の時表示 &ndash;&gt;-->
+<!--                                <p th:if="${#lists.isEmpty(recommendList)}" id="recommendListDiv" class="sm:text-lg text-base text-danger my-4">-->
+<!--                                    先に出発地点、終了地点、目的のどれかを入力してください。-->
+<!--                                </p>-->
+<!--                                &lt;!&ndash; ローディングの表示をおすすめ目的地取得の時に切り替える &ndash;&gt;-->
+<!--                                <div class="hidden items-center" id="loadingDiv">-->
+<!--                                    <span class="mx-2 text-lg">おすすめ目的地を検索中</span>-->
+<!--                                    <th:block th:replace="~{fragment/svg :: loading}"/>-->
+<!--                                </div>-->
+<!--                                <div id="recommendToggleDiv">-->
+<!--                                    &lt;!&ndash; おすすめ目的地の 目的地作成リスト 仮:${recommendList} を使う &ndash;&gt;-->
+<!--    &lt;!&ndash;                                <th:block th:if="${!#lists.isEmpty(recommendList)}" th:insert="~{fragment/recommend :: recommendToggle(__${recommendList}__)}"/>&ndash;&gt;-->
+<!--                                </div>-->
+<!--                            </details>-->
+<!--                        </section>-->
+                        <!-- 利用する交通手段のセクション -->
+                    </div>
+                    <!-- ボタンのセクション -->
+                    <section class="mb-20">
+                        <div class="flex justify-center">
+                            <!-- ボタンイベント editButtons.js -->
+                            <button type="button" id="backButton" class="sm:mx-10 mx-5 block items-center justify-center button-secondary">保存して戻る</button>
+                            <!-- titleとオプションのupdateをし、経路生成処理に送信 -->
+                            <button type="button" id="crateRouteButton" class="sm:mx-10 mx-5 block items-center justify-center button-primary">経路生成</button>
+                        </div>
+                        <!-- 経路生成済みか を判別して表示切替-->
+                        <div class="flex justify-center mt-10" id="editButtonsDiv">
+                            <!-- 日付追加ボタンで同じ画面にリダイレクト -->
+                            <button type="button" class="sm:mx-10 mx-5 flex items-center justify-center button-secondary" id="addDayButton">
+                                <th:block th:replace="~{fragment/svg :: plus}"/>
+                                日付の追加
+                            </button>
+                            <!-- プラン確定処理に飛ばす -->
+                            <button type="button" class="sm:mx-10 mx-5 block items-center justify-center button-primary" id="planConfirmButton">プラン確定</button>
+                        </div>
+                    </section>
+                </section>
+                <!-- マップ表示のセクション -->
+                <section class="sm:w-1/2 hidden sm:inline-block">
+                    <div id="map" class="w-full h-full"></div>
+                </section>
+            </div>
+        </form>
+    </div>
+<!--  おすすめ目的地  -->
+<!--        <div id="recommendFormDiv">-->
+<!--            <th:block th:if="${!#lists.isEmpty(recommendList)}" th:insert="~{fragment/recommend :: recommendForm(${recommendList})}"/>-->
+<!--        </div>-->
+</main>
+<th:block th:replace="~{fragment/footer :: footer}"/>
+<script src="/js/draganddrop.js"></script>
+<th:block th:replace="~{fragment/script :: flowbite}"/>
+<th:block th:replace="~{fragment/script :: map}"/>
+<th:block th:replace="~{fragment/script :: previewImage}"/>
+<!--<th:block th:replace="~{fragment/script :: modal}"/>-->
+<!--<th:block th:replace="~{fragment/script :: planEdit}"/>-->
+<th:block th:replace="~{fragment/script :: googleMapsAPI}"/>
+</body>
+</html>

--- a/src/main/resources/templates/plan/edit.html
+++ b/src/main/resources/templates/plan/edit.html
@@ -45,7 +45,7 @@
                         <div th:each="index : ${#numbers.sequence(1, travelDays)}">
                             <!-- todo: selectedDayにはパラメータのdayを入れる -->
                             <a th:href="@{/plan/edit/__${editPlanForm.uuid}__(day=__${index}__)}"
-                               th:classappend="${index == selectedDay} ? 'pt-5 pb-3 sm:px-6 lg:px-12 px-8 bg-green-600 text-white text-lg h-12' : 'pt-3 pb-3 sm:px-4 lg:px-10 px-6 bg-green-400 text-white'"
+                               th:classappend="${index == currentDay} ? 'pt-5 pb-3 sm:px-6 lg:px-12 px-8 bg-green-600 text-white text-lg h-12' : 'pt-3 pb-3 sm:px-4 lg:px-10 px-6 bg-green-400 text-white'"
                                class="rounded-t-md text-center items-center cursor-pointer">
                                 <span th:text="${index} + '日目'"></span>
                             </a>
@@ -72,9 +72,9 @@
                             <th:block th:replace="~{fragment/update-modal :: endUpdate}"/>
                         </div>
                         <!-- 経路生成後の目的地追加表示 -->
-                        <div class="addPlaces">
-                            <th:block th:replace="~{fragment/modal :: places}"/>
-                        </div>
+<!--                        <div class="addPlaces">-->
+<!--                            <th:block th:replace="~{fragment/modal :: places}"/>-->
+<!--                        </div>-->
                         <!-- おすすめ目的地のセクション　一旦コメント化-->
 <!--                        <section class="pt-10">-->
 <!--                            <details open class="p-4 group overflow-hidden transition-[max-height] duration-500">-->


### PR DESCRIPTION
## 概要
編集画面のハリボテ作成

### Issue

- close

### 変更内容

<!-- 適宜スクリーンショットを添付 -->

https://github.com/user-attachments/assets/dd0a426f-6794-4179-808c-ed1090e22fc1

- [x] それぞれのformをdivタグで th:object に
- [x] update-modal で th:fieldに設定
- [x] update-modal の トグルボタンとフォームを一緒に
- [x] JSはコメント化のまま
- [x] 目的地追加のボタン削除

表示用 仮Controller
```
    public String get(final @PathVariable String uuid,
                      final @RequestParam(required = false, defaultValue = "1") int day,
                      final Model model) {
        model.addAttribute("editPlanForm", new EditPlanForm());
        model.addAttribute("googleMapsApiKey", googleMapsApiKey);

        List<EditWaypointForm> waypoints = new ArrayList<>();
        waypoints.add(new EditWaypointForm(1,"label", "placeId", LocalDateTime.now(), 60, Transporation.DRIVE, 3000 ));
        waypoints.add(new EditWaypointForm(2,"label2", "placeId2", LocalDateTime.now().plusHours(2), 30, Transporation.BICYCLE, 4000 ));

        EditWaypointListForm editWaypointListForm = new EditWaypointListForm(
                1,
                Transporation.DRIVE,
                new EditDeparturePointForm(1,"start","startP",LocalDateTime.now(),Transporation.WALK),
                waypoints,
                new EditDestinationPointForm(1,"end","test")
        );
        model.addAttribute("editWaypointListForm", editWaypointListForm);

        model.addAttribute("currentDay", day);
        model.addAttribute("travelDays", 2);

        return "plan/edit";
    }
```